### PR TITLE
Fix issue with Google Universal Handler where page overriding with JSON object doesn't work

### DIFF
--- a/src/googleHandler.js
+++ b/src/googleHandler.js
@@ -16,7 +16,7 @@
         var service = {};
 
         service.trackPageView = function (url) {
-            ga('send', 'pageView', { 'page': url });
+            ga('send', 'pageView', url);
         };
 
         service.trackEvent = function (category, action, opt_label, opt_value, opt_noninteraction) {


### PR DESCRIPTION
Changed to the ga('send', 'pageview','/my-overriden-page?id=1') format as specified at https://developers.google.com/analytics/devguides/collection/analyticsjs/pages
