### PR TITLE
Add AngularyticsProvider.setPageChangeEvent()

### DIFF
--- a/src/angularytics.js
+++ b/src/angularytics.js
@@ -15,6 +15,11 @@
         var capitalizeHandler = function(handler) {
             return handler.charAt(0).toUpperCase() + handler.substring(1);
         }
+        
+        var pageChangeEvent = '$locationChangeSuccess';
+        this.setPageChangeEvent = function(newPageChangeEvent) {
+          pageChangeEvent = newPageChangeEvent;
+        }
 
         this.$get = function($injector, $rootScope, $location) {
 
@@ -32,7 +37,7 @@
             }
 
             // Event listeing
-            $rootScope.$on('$locationChangeSuccess', function() {
+            $rootScope.$on(pageChangeEvent, function() {
                 forEachHandlerDo(function(handler) {
                     var url = $location.path();
                     if (url) {


### PR DESCRIPTION
Enables the customization of the page change event that is used to automatically generate page view events. This is important for use in ui-router and perhaps other alternatives to default angular routing.

``` javascript
AngularyticsProvider.setPageChangeEvent("$stateChangeSuccess");
```
