### PR TITLE
Change GoogleUniversal to set page as well

### DIFF
--- a/src/googleHandler.js
+++ b/src/googleHandler.js
@@ -16,7 +16,8 @@
         var service = {};
 
         service.trackPageView = function (url) {
-            ga('send', 'pageView', url);
+            ga('set', 'page', url);
+            ga('send', 'pageView');
         };
 
         service.trackEvent = function (category, action, opt_label, opt_value, opt_noninteraction) {


### PR DESCRIPTION
This has additional benefit that future trackEvent() calls will use the new page value as well.

Also, it silences a minor warning from the Analytics Debugger.
