### PR TITLE
add trackPageView(url)

### DIFF
--- a/src/angularytics.js
+++ b/src/angularytics.js
@@ -59,6 +59,14 @@
                     }
                 });
             }
+            
+            service.trackPageView = function(url) {
+                forEachHandlerDo(function(handler) {
+                    if (url) {
+                        handler.trackPageView(url);
+                    }
+                });
+            }
 
             return service;
 


### PR DESCRIPTION
Add trackPageView(url) to be possible to track page views that don't reflect in url change, for instance if showing content in an overlay.
