### PR TITLE
Add ability to disable page view tracking

### DIFF
--- a/src/angularytics.js
+++ b/src/angularytics.js
@@ -20,6 +20,11 @@
         this.setPageChangeEvent = function(newPageChangeEvent) {
           pageChangeEvent = newPageChangeEvent;
         };
+        
+        var pageViewTrackingEnabled = true;
+        this.disablePageViewTracking = function(){
+            pageViewTrackingEnabled = false;
+        };
 
         this.$get = function($injector, $rootScope, $location) {
 
@@ -67,9 +72,11 @@
             };
             
             // Event listening
-            $rootScope.$on(pageChangeEvent, function() {
-                service.trackPageView($location.url())
-            });
+            if(pageViewTrackingEnabled){
+                $rootScope.$on(pageChangeEvent, function() {
+                    service.trackPageView($location.url())
+                });
+            }
 
             return service;
 


### PR DESCRIPTION
Add ability to disable page view tracking through the `Angularytics` provider.

At my company, we don't have an SPA, so we don't have any way to track page changes. This change just allows me to disable the tracking all together so that it doesn't setup the listener for that `$rootScope` event.